### PR TITLE
Support building channel when multiple collections contain search term

### DIFF
--- a/scripts/channel_builder.py
+++ b/scripts/channel_builder.py
@@ -90,11 +90,14 @@ for section in args.section:
     if args.collection is not None:
         for collection in args.collection:
             found_coll = plex_server.library.section(section).search(title=collection, libtype='collection')
-            if found_coll and len(found_coll) == 1:
-                print("Matching COLLECTION items:")
-                for item in found_coll[0].children:
-                    print(f"{collection} - {item.title}")
-                all_items.extend(found_coll[0].children)
+            if found_coll and len(found_coll) > 0:
+                for coll in found_coll:
+                    if coll.title == collection:
+                        print("Matching COLLECTION items:")
+                        for item in coll.children:
+                            print(f"{collection} - {item.title}")
+                        all_items.extend(found_coll[0].children)
+                        break
 
 if all_items:
     answer = input("Would you like to proceed with making the channel? (Y/N) ")


### PR DESCRIPTION
I wanted to use this to build a channel for a "smart collection" that contained the term "**Animation**"; however it failed because .search() includes results when it isn't an exact match, so I also got results back for "Sony Animation", "Disney Animation", etc. collections, which caused the script to fail. These edits fix this, and require an exact match for the supplied collection name.